### PR TITLE
New rules and allow non-floating clients to disable titlebar

### DIFF
--- a/config/awesome/floppy/configuration/client/rules.lua
+++ b/config/awesome/floppy/configuration/client/rules.lua
@@ -18,6 +18,7 @@ awful.rules.rules = {
       }
     },
     properties = {
+	  round_corners = true,
       focus = awful.client.focus.filter,
       raise = true,
       keys = client_keys,
@@ -31,12 +32,8 @@ awful.rules.rules = {
       ontop = false,
       sticky = false,
       maximized_horizontal = false,
-      maximized_vertical = false
-
+      maximized_vertical = false  
     }
-  },
-  { rule_any = { name = {'QuakeTerminal'} },
-    properties = { skip_decoration = true }
   },
 
   -- Terminals
@@ -46,7 +43,8 @@ awful.rules.rules = {
         "URxvt",
   			"XTerm",
   			"UXTerm",
-        "kitty"
+        "kitty",
+		"K3rmit"
        },
     },
     properties = {
@@ -54,7 +52,6 @@ awful.rules.rules = {
       screen = 1, 
       tag = '1',
       switchtotag = true,
-      hide_titlebars = false
     }
   },
 

--- a/config/awesome/floppy/module/quake-terminal.lua
+++ b/config/awesome/floppy/module/quake-terminal.lua
@@ -50,9 +50,11 @@ _G.client.connect_signal(
       c.hidden = not opened
       c.maximized_horizontal = true
       c.hide_titlebars = true
+	  c.skip_center = true
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end
+	  awful.placement.top(c)
     end
   end
 )

--- a/config/awesome/floppy/module/quake-terminal.lua
+++ b/config/awesome/floppy/module/quake-terminal.lua
@@ -51,6 +51,7 @@ _G.client.connect_signal(
       c.maximized_horizontal = true
       c.hide_titlebars = true
 	  c.skip_center = true
+	  c.round_corners = false
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end

--- a/config/awesome/floppy/module/quake-terminal.lua
+++ b/config/awesome/floppy/module/quake-terminal.lua
@@ -49,7 +49,7 @@ _G.client.connect_signal(
       c.sticky = true
       c.hidden = not opened
       c.maximized_horizontal = true
-      c.titlebars_enabled = false
+      c.hide_titlebars = true
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end

--- a/config/awesome/floppy/module/titlebar-decorate-client.lua
+++ b/config/awesome/floppy/module/titlebar-decorate-client.lua
@@ -17,33 +17,38 @@ local roundCorners = function(cr, width, height)
   gears.shape.rounded_rect(cr, width, height, beautiful.corner_radius)
 end
 
+-- On Spawn
+_G.client.connect_signal("manage", function(c)
+  if not c.max then
+    awful.titlebar.show(c, 'left')
+  else
+    awful.titlebar.hide(c, 'left')
+  end
+end)
+
 _G.screen.connect_signal("arrange", function(s)
   for _, c in pairs(s.clients) do
-    if (#s.tiled_clients > 0 or c.floating) and (c.first_tag.layout.name ~= 'max' or not c.max) then
+    if (#s.tiled_clients > 1 or c.floating) and c.first_tag.layout.name ~= 'max' then
       if not c.hide_titlebars then
 	    awful.titlebar.show(c, 'left')
 	  else 
 		awful.titlebar.hide(c, 'left')
 	  end
+	  if c.floating and not c.skip_center then
+		awful.placement.centered(c)
+	  end
       if c.maximized then
         c.shape = function(cr, w, h)
-        gears.shape.rectangle(cr, w, h)
+          gears.shape.rectangle(cr, w, h)
+        end
+      else 
+        c.shape = roundCorners
       end
-    else 
-      c.shape = roundCorners
-    end
-
-    if c.floating and not c.skip_center then
-      awful.placement.centered(c)
-    end
-
-    else if c.first_tag.layout.name == 'max' or c.max then
+    elseif #s.tiled_clients == 1 or c.first_tag.layout.name == 'max' then
       awful.titlebar.hide(c, 'left')
       c.shape = function(cr, w, h)
-      gears.shape.rectangle(cr, w, h)
-    end
+        gears.shape.rectangle(cr, w, h)
       end
     end
-
   end
 end)

--- a/config/awesome/floppy/module/titlebar-decorate-client.lua
+++ b/config/awesome/floppy/module/titlebar-decorate-client.lua
@@ -37,7 +37,7 @@ _G.screen.connect_signal("arrange", function(s)
 	  if c.floating and not c.skip_center then
 		awful.placement.centered(c)
 	  end
-      if c.maximized then
+      if c.maximized or not c.round_corners then
         c.shape = function(cr, w, h)
           gears.shape.rectangle(cr, w, h)
         end

--- a/config/awesome/floppy/module/titlebar-decorate-client.lua
+++ b/config/awesome/floppy/module/titlebar-decorate-client.lua
@@ -13,26 +13,18 @@ local titlebars = {}
 local theme = {}
 local dpi = require('beautiful').xresources.apply_dpi
 
-
 local roundCorners = function(cr, width, height)
   gears.shape.rounded_rect(cr, width, height, beautiful.corner_radius)
 end
---
-
--- On Spawn
-_G.client.connect_signal("manage", function(c)
-  if not c.max then
-    awful.titlebar.show(c, 'left')
-  else
-    awful.titlebar.hide(c, 'left')
-  end
-end)
-
 
 _G.screen.connect_signal("arrange", function(s)
   for _, c in pairs(s.clients) do
-    if (#s.tiled_clients > 1 or c.floating) and c.first_tag.layout.name ~= 'max' then
-      awful.titlebar.show(c, 'left')
+    if (#s.tiled_clients > 0 or c.floating) and (c.first_tag.layout.name ~= 'max' or not c.max) then
+      if not c.hide_titlebars then
+	    awful.titlebar.show(c, 'left')
+	  else 
+		awful.titlebar.hide(c, 'left')
+	  end
       if c.maximized then
         c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
@@ -43,13 +35,9 @@ _G.screen.connect_signal("arrange", function(s)
 
     if c.floating then
       awful.placement.centered(c)
-      -- Hide titlebar if hide_titlebars is true in rules
-      if c.hide_titlebars then
-        awful.titlebar.hide(c, 'left')
-      end
     end
 
-    else if #s.tiled_clients == 1 or c.first_tag.layout.name == 'max' then
+    else if c.first_tag.layout.name == 'max' or c.max then
       awful.titlebar.hide(c, 'left')
       c.shape = function(cr, w, h)
       gears.shape.rectangle(cr, w, h)

--- a/config/awesome/floppy/module/titlebar-decorate-client.lua
+++ b/config/awesome/floppy/module/titlebar-decorate-client.lua
@@ -33,7 +33,7 @@ _G.screen.connect_signal("arrange", function(s)
       c.shape = roundCorners
     end
 
-    if c.floating then
+    if c.floating and not c.skip_center then
       awful.placement.centered(c)
     end
 

--- a/config/awesome/lines/configuration/client/rules.lua
+++ b/config/awesome/lines/configuration/client/rules.lua
@@ -18,6 +18,7 @@ awful.rules.rules = {
       }
     },
     properties = {
+	  round_corners = true,
       focus = awful.client.focus.filter,
       raise = true,
       keys = client_keys,
@@ -31,12 +32,8 @@ awful.rules.rules = {
       ontop = false,
       sticky = false,
       maximized_horizontal = false,
-      maximized_vertical = false
-
+      maximized_vertical = false  
     }
-  },
-  { rule_any = { name = {'QuakeTerminal'} },
-    properties = { skip_decoration = true }
   },
 
   -- Terminals
@@ -46,7 +43,8 @@ awful.rules.rules = {
         "URxvt",
   			"XTerm",
   			"UXTerm",
-        "kitty"
+        "kitty",
+		"K3rmit"
        },
     },
     properties = {
@@ -54,7 +52,6 @@ awful.rules.rules = {
       screen = 1, 
       tag = '1',
       switchtotag = true,
-      hide_titlebars = false
     }
   },
 

--- a/config/awesome/lines/module/quake-terminal.lua
+++ b/config/awesome/lines/module/quake-terminal.lua
@@ -50,9 +50,11 @@ _G.client.connect_signal(
       c.hidden = not opened
       c.maximized_horizontal = true
       c.hide_titlebars = true
+	  c.skip_center = true
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end
+	  awful.placement.top(c)
     end
   end
 )

--- a/config/awesome/lines/module/quake-terminal.lua
+++ b/config/awesome/lines/module/quake-terminal.lua
@@ -51,6 +51,7 @@ _G.client.connect_signal(
       c.maximized_horizontal = true
       c.hide_titlebars = true
 	  c.skip_center = true
+	  c.round_corners = false
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end

--- a/config/awesome/lines/module/quake-terminal.lua
+++ b/config/awesome/lines/module/quake-terminal.lua
@@ -49,7 +49,7 @@ _G.client.connect_signal(
       c.sticky = true
       c.hidden = not opened
       c.maximized_horizontal = true
-      c.titlebars_enabled = false
+      c.hide_titlebars = true
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end

--- a/config/awesome/lines/module/titlebar-decorate-client.lua
+++ b/config/awesome/lines/module/titlebar-decorate-client.lua
@@ -17,33 +17,38 @@ local roundCorners = function(cr, width, height)
   gears.shape.rounded_rect(cr, width, height, beautiful.corner_radius)
 end
 
+-- On Spawn
+_G.client.connect_signal("manage", function(c)
+  if not c.max then
+    awful.titlebar.show(c, 'left')
+  else
+    awful.titlebar.hide(c, 'left')
+  end
+end)
+
 _G.screen.connect_signal("arrange", function(s)
   for _, c in pairs(s.clients) do
-    if (#s.tiled_clients > 0 or c.floating) and (c.first_tag.layout.name ~= 'max' or not c.max) then
+    if (#s.tiled_clients > 1 or c.floating) and c.first_tag.layout.name ~= 'max' then
       if not c.hide_titlebars then
 	    awful.titlebar.show(c, 'left')
 	  else 
 		awful.titlebar.hide(c, 'left')
 	  end
+	  if c.floating and not c.skip_center then
+		awful.placement.centered(c)
+	  end
       if c.maximized then
         c.shape = function(cr, w, h)
-        gears.shape.rectangle(cr, w, h)
+          gears.shape.rectangle(cr, w, h)
+        end
+      else 
+        c.shape = roundCorners
       end
-    else 
-      c.shape = roundCorners
-    end
-
-    if c.floating and not c.skip_center then
-      awful.placement.centered(c)
-    end
-
-    else if c.first_tag.layout.name == 'max' or c.max then
+    elseif #s.tiled_clients == 1 or c.first_tag.layout.name == 'max' then
       awful.titlebar.hide(c, 'left')
       c.shape = function(cr, w, h)
-      gears.shape.rectangle(cr, w, h)
-    end
+        gears.shape.rectangle(cr, w, h)
       end
     end
-
   end
 end)

--- a/config/awesome/lines/module/titlebar-decorate-client.lua
+++ b/config/awesome/lines/module/titlebar-decorate-client.lua
@@ -13,26 +13,18 @@ local titlebars = {}
 local theme = {}
 local dpi = require('beautiful').xresources.apply_dpi
 
-
 local roundCorners = function(cr, width, height)
   gears.shape.rounded_rect(cr, width, height, beautiful.corner_radius)
 end
---
-
--- On Spawn
-_G.client.connect_signal("manage", function(c)
-  if not c.max then
-    awful.titlebar.show(c, 'top')
-  else
-    awful.titlebar.hide(c, 'top')
-  end
-end)
-
 
 _G.screen.connect_signal("arrange", function(s)
   for _, c in pairs(s.clients) do
-    if (#s.tiled_clients > 1 or c.floating) and c.first_tag.layout.name ~= 'max' then
-      awful.titlebar.show(c, 'top')
+    if (#s.tiled_clients > 0 or c.floating) and (c.first_tag.layout.name ~= 'max' or not c.max) then
+      if not c.hide_titlebars then
+	    awful.titlebar.show(c, 'left')
+	  else 
+		awful.titlebar.hide(c, 'left')
+	  end
       if c.maximized then
         c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
@@ -43,14 +35,10 @@ _G.screen.connect_signal("arrange", function(s)
 
     if c.floating then
       awful.placement.centered(c)
-      -- Hide titlebar if hide_titlebars is true in rules
-      if c.hide_titlebars then
-        awful.titlebar.hide(c, 'top')
-      end
     end
 
-    else if #s.tiled_clients == 1 or c.first_tag.layout.name == 'max' then
-      awful.titlebar.hide(c, 'top')
+    else if c.first_tag.layout.name == 'max' or c.max then
+      awful.titlebar.hide(c, 'left')
       c.shape = function(cr, w, h)
       gears.shape.rectangle(cr, w, h)
     end

--- a/config/awesome/lines/module/titlebar-decorate-client.lua
+++ b/config/awesome/lines/module/titlebar-decorate-client.lua
@@ -37,7 +37,7 @@ _G.screen.connect_signal("arrange", function(s)
 	  if c.floating and not c.skip_center then
 		awful.placement.centered(c)
 	  end
-      if c.maximized then
+      if c.maximized or not c.round_corners then
         c.shape = function(cr, w, h)
           gears.shape.rectangle(cr, w, h)
         end

--- a/config/awesome/lines/module/titlebar-decorate-client.lua
+++ b/config/awesome/lines/module/titlebar-decorate-client.lua
@@ -33,7 +33,7 @@ _G.screen.connect_signal("arrange", function(s)
       c.shape = roundCorners
     end
 
-    if c.floating then
+    if c.floating and not c.skip_center then
       awful.placement.centered(c)
     end
 

--- a/config/awesome/rounded/configuration/client/rules.lua
+++ b/config/awesome/rounded/configuration/client/rules.lua
@@ -18,6 +18,7 @@ awful.rules.rules = {
       }
     },
     properties = {
+	  round_corners = true,
       focus = awful.client.focus.filter,
       raise = true,
       keys = client_keys,
@@ -31,12 +32,8 @@ awful.rules.rules = {
       ontop = false,
       sticky = false,
       maximized_horizontal = false,
-      maximized_vertical = false
-
+      maximized_vertical = false  
     }
-  },
-  { rule_any = { name = {'QuakeTerminal'} },
-    properties = { skip_decoration = true }
   },
 
   -- Terminals
@@ -46,7 +43,8 @@ awful.rules.rules = {
         "URxvt",
   			"XTerm",
   			"UXTerm",
-        "kitty"
+        "kitty",
+		"K3rmit"
        },
     },
     properties = {
@@ -54,7 +52,6 @@ awful.rules.rules = {
       screen = 1, 
       tag = '1',
       switchtotag = true,
-      hide_titlebars = false
     }
   },
 

--- a/config/awesome/rounded/module/quake-terminal.lua
+++ b/config/awesome/rounded/module/quake-terminal.lua
@@ -50,9 +50,11 @@ _G.client.connect_signal(
       c.hidden = not opened
       c.maximized_horizontal = true
       c.hide_titlebars = true
+	  c.skip_center = true
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end
+	  awful.placement.top(c)
     end
   end
 )

--- a/config/awesome/rounded/module/quake-terminal.lua
+++ b/config/awesome/rounded/module/quake-terminal.lua
@@ -51,6 +51,7 @@ _G.client.connect_signal(
       c.maximized_horizontal = true
       c.hide_titlebars = true
 	  c.skip_center = true
+	  c.round_corners = false
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end

--- a/config/awesome/rounded/module/quake-terminal.lua
+++ b/config/awesome/rounded/module/quake-terminal.lua
@@ -49,7 +49,7 @@ _G.client.connect_signal(
       c.sticky = true
       c.hidden = not opened
       c.maximized_horizontal = true
-      c.titlebars_enabled = false
+      c.hide_titlebars = true
       c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
       end

--- a/config/awesome/rounded/module/titlebar-decorate-client.lua
+++ b/config/awesome/rounded/module/titlebar-decorate-client.lua
@@ -17,33 +17,38 @@ local roundCorners = function(cr, width, height)
   gears.shape.rounded_rect(cr, width, height, beautiful.corner_radius)
 end
 
+-- On Spawn
+_G.client.connect_signal("manage", function(c)
+  if not c.max then
+    awful.titlebar.show(c, 'left')
+  else
+    awful.titlebar.hide(c, 'left')
+  end
+end)
+
 _G.screen.connect_signal("arrange", function(s)
   for _, c in pairs(s.clients) do
-    if (#s.tiled_clients > 0 or c.floating) and (c.first_tag.layout.name ~= 'max' or not c.max) then
+    if (#s.tiled_clients > 1 or c.floating) and c.first_tag.layout.name ~= 'max' then
       if not c.hide_titlebars then
 	    awful.titlebar.show(c, 'left')
 	  else 
 		awful.titlebar.hide(c, 'left')
 	  end
+	  if c.floating and not c.skip_center then
+		awful.placement.centered(c)
+	  end
       if c.maximized then
         c.shape = function(cr, w, h)
-        gears.shape.rectangle(cr, w, h)
+          gears.shape.rectangle(cr, w, h)
+        end
+      else 
+        c.shape = roundCorners
       end
-    else 
-      c.shape = roundCorners
-    end
-
-    if c.floating and not c.skip_center then
-      awful.placement.centered(c)
-    end
-
-    else if c.first_tag.layout.name == 'max' or c.max then
+    elseif #s.tiled_clients == 1 or c.first_tag.layout.name == 'max' then
       awful.titlebar.hide(c, 'left')
       c.shape = function(cr, w, h)
-      gears.shape.rectangle(cr, w, h)
-    end
+        gears.shape.rectangle(cr, w, h)
       end
     end
-
   end
 end)

--- a/config/awesome/rounded/module/titlebar-decorate-client.lua
+++ b/config/awesome/rounded/module/titlebar-decorate-client.lua
@@ -37,7 +37,7 @@ _G.screen.connect_signal("arrange", function(s)
 	  if c.floating and not c.skip_center then
 		awful.placement.centered(c)
 	  end
-      if c.maximized then
+      if c.maximized or not c.round_corners then
         c.shape = function(cr, w, h)
           gears.shape.rectangle(cr, w, h)
         end

--- a/config/awesome/rounded/module/titlebar-decorate-client.lua
+++ b/config/awesome/rounded/module/titlebar-decorate-client.lua
@@ -13,26 +13,18 @@ local titlebars = {}
 local theme = {}
 local dpi = require('beautiful').xresources.apply_dpi
 
-
 local roundCorners = function(cr, width, height)
   gears.shape.rounded_rect(cr, width, height, beautiful.corner_radius)
 end
---
-
--- On Spawn
-_G.client.connect_signal("manage", function(c)
-  if not c.max then
-    awful.titlebar.show(c, 'left')
-  else
-    awful.titlebar.hide(c, 'left')
-  end
-end)
-
 
 _G.screen.connect_signal("arrange", function(s)
   for _, c in pairs(s.clients) do
-    if (#s.tiled_clients > 1 or c.floating) and c.first_tag.layout.name ~= 'max' then
-      awful.titlebar.show(c, 'left')
+    if (#s.tiled_clients > 0 or c.floating) and (c.first_tag.layout.name ~= 'max' or not c.max) then
+      if not c.hide_titlebars then
+	    awful.titlebar.show(c, 'left')
+	  else 
+		awful.titlebar.hide(c, 'left')
+	  end
       if c.maximized then
         c.shape = function(cr, w, h)
         gears.shape.rectangle(cr, w, h)
@@ -43,13 +35,9 @@ _G.screen.connect_signal("arrange", function(s)
 
     if c.floating then
       awful.placement.centered(c)
-      -- Hide titlebar if hide_titlebars is true in rules
-      if c.hide_titlebars then
-        awful.titlebar.hide(c, 'left')
-      end
     end
 
-    else if #s.tiled_clients == 1 or c.first_tag.layout.name == 'max' then
+    else if c.first_tag.layout.name == 'max' or c.max then
       awful.titlebar.hide(c, 'left')
       c.shape = function(cr, w, h)
       gears.shape.rectangle(cr, w, h)

--- a/config/awesome/rounded/module/titlebar-decorate-client.lua
+++ b/config/awesome/rounded/module/titlebar-decorate-client.lua
@@ -33,7 +33,7 @@ _G.screen.connect_signal("arrange", function(s)
       c.shape = roundCorners
     end
 
-    if c.floating then
+    if c.floating and not c.skip_center then
       awful.placement.centered(c)
     end
 


### PR DESCRIPTION
skip_center: Let floating clients be placed manually (instead of locking them in the center)
round_corners: Whether the client would have round_corners

These were mainly done cause the quake terminal was messed up :P