### PR TITLE
[LOCKSCREEN] fix type error when input_password is nil

### DIFF
--- a/config/awesome/floppy/module/lockscreen.lua
+++ b/config/awesome/floppy/module/lockscreen.lua
@@ -533,7 +533,11 @@ local locker = function(s)
 				type_again = false
 
 				-- Validate password
-				local pam_auth = pam:auth_current_user(input_password)
+				local pam_auth = false
+				if input_password ~= nil
+				then
+					pam_auth = pam:auth_current_user(input_password)
+				end
 				if pam_auth then
 					-- Come in!
 					self:stop()

--- a/config/awesome/gnawesome/module/lockscreen.lua
+++ b/config/awesome/gnawesome/module/lockscreen.lua
@@ -533,7 +533,11 @@ local locker = function(s)
 				type_again = false
 
 				-- Validate password
-				local pam_auth = pam:auth_current_user(input_password)
+				local pam_auth = false
+				if input_password ~= nil
+				then
+					pam_auth = pam:auth_current_user(input_password)
+				end
 				if pam_auth then
 					-- Come in!
 					self:stop()

--- a/config/awesome/linear/module/lockscreen.lua
+++ b/config/awesome/linear/module/lockscreen.lua
@@ -533,7 +533,11 @@ local locker = function(s)
 				type_again = false
 
 				-- Validate password
-				local pam_auth = pam:auth_current_user(input_password)
+				local pam_auth = false
+				if input_password ~= nil
+				then
+					pam_auth = pam:auth_current_user(input_password)
+				end
 				if pam_auth then
 					-- Come in!
 					self:stop()


### PR DESCRIPTION
I found when i directly enter the "Enter" key on lockscreen, it will cause type error because input_password is nil, the argument of auth_current_user must be a string.