### PR TITLE
config/awesome/*/widget/task-list.lua: protect utf8_sub() from partic…

### DIFF
--- a/config/awesome/floppy/widget/task-list.lua
+++ b/config/awesome/floppy/widget/task-list.lua
@@ -13,7 +13,7 @@ local icons = require('theme.icons')
 -- @j index of end position
 local function utf8_sub(s, i, j)
     i = utf8.offset(s, i)
-    j = utf8.offset(s, j + 1) - 1
+    j = (utf8.offset(s, j + 1) or j+1) - 1
     return string.sub(s, i, j)
 end
 

--- a/config/awesome/floppy/widget/task-list.lua
+++ b/config/awesome/floppy/widget/task-list.lua
@@ -13,7 +13,7 @@ local icons = require('theme.icons')
 -- @j index of end position
 local function utf8_sub(s, i, j)
     i = utf8.offset(s, i)
-    j = (utf8.offset(s, j + 1) or j+1) - 1
+    j = (utf8.offset(s, j + 1) or j + 1) - 1
     return string.sub(s, i, j)
 end
 

--- a/config/awesome/gnawesome/widget/task-list.lua
+++ b/config/awesome/gnawesome/widget/task-list.lua
@@ -13,7 +13,7 @@ local icons = require('theme.icons')
 -- @j index of end position
 local function utf8_sub(s, i, j)
     i = utf8.offset(s, i)
-    j = utf8.offset(s, j + 1) - 1
+    j = (utf8.offset(s, j + 1) or j+1) - 1
     return string.sub(s, i, j)
 end
 

--- a/config/awesome/gnawesome/widget/task-list.lua
+++ b/config/awesome/gnawesome/widget/task-list.lua
@@ -13,7 +13,7 @@ local icons = require('theme.icons')
 -- @j index of end position
 local function utf8_sub(s, i, j)
     i = utf8.offset(s, i)
-    j = (utf8.offset(s, j + 1) or j+1) - 1
+    j = (utf8.offset(s, j + 1) or j + 1) - 1
     return string.sub(s, i, j)
 end
 
@@ -26,7 +26,7 @@ local function create_buttons(buttons, object)
 		local btns = {}
 		for _, b in ipairs(buttons) do
 			-- Create a proxy button object: it will receive the real
-			-- press and release events, and will propagate them to the
+2			-- press and release events, and will propagate them to the
 			-- button object the user provided, but with the object as
 			-- argument.
 			local btn = capi.button {modifiers = b.modifiers, button = b.button}

--- a/config/awesome/gnawesome/widget/task-list.lua
+++ b/config/awesome/gnawesome/widget/task-list.lua
@@ -26,7 +26,7 @@ local function create_buttons(buttons, object)
 		local btns = {}
 		for _, b in ipairs(buttons) do
 			-- Create a proxy button object: it will receive the real
-2			-- press and release events, and will propagate them to the
+			-- press and release events, and will propagate them to the
 			-- button object the user provided, but with the object as
 			-- argument.
 			local btn = capi.button {modifiers = b.modifiers, button = b.button}

--- a/config/awesome/linear/widget/task-list.lua
+++ b/config/awesome/linear/widget/task-list.lua
@@ -13,7 +13,7 @@ local icons = require('theme.icons')
 -- @j index of end position
 local function utf8_sub(s, i, j)
     i = utf8.offset(s, i)
-    j = utf8.offset(s, j + 1) - 1
+    j = (utf8.offset(s, j + 1) or j+1) - 1
     return string.sub(s, i, j)
 end
 

--- a/config/awesome/linear/widget/task-list.lua
+++ b/config/awesome/linear/widget/task-list.lua
@@ -13,7 +13,7 @@ local icons = require('theme.icons')
 -- @j index of end position
 local function utf8_sub(s, i, j)
     i = utf8.offset(s, i)
-    j = (utf8.offset(s, j + 1) or j+1) - 1
+    j = (utf8.offset(s, j + 1) or j + 1) - 1
     return string.sub(s, i, j)
 end
 


### PR DESCRIPTION
…ular UTF-8 strings

Fixes the following bug: Some windows are missing in the task list. With such errors:
```
2020-04-16 20:37:03 E: awesome: Error during a protected call: /home/ildar/.config/awesome/widget/task-list.lua:16: attempt to perform arithmetic on a nil value
stack traceback:
	/home/ildar/.config/awesome/widget/task-list.lua:16: in upvalue 'utf8_sub'
	/home/ildar/.config/awesome/widget/task-list.lua:163: in local 'update_function'
	/usr/share/awesome/lib/awful/widget/tasklist.lua:594: in upvalue 'tasklist_update'
	/usr/share/awesome/lib/awful/widget/tasklist.lua:706: in function </usr/share/awesome/lib/awful/widget/tasklist.lua:703>
	[C]: in function 'xpcall'
	/usr/share/awesome/lib/gears/protected_call.lua:36: in function </usr/share/awesome/lib/gears/protected_call.lua:35>
	(...tail calls...)
	/usr/share/awesome/lib/gears/timer.lua:245: in function 'gears.timer.run_delayed_calls_now'
```
