### PR TITLE
Added a comma. Yep.

### DIFF
--- a/config/awesome/surreal/configuration/apps.lua
+++ b/config/awesome/surreal/configuration/apps.lua
@@ -87,7 +87,7 @@ return {
 		[[
 		xidlehook --not-when-fullscreen --not-when-audio --timer 600 \
 		"awesome-client 'awesome.emit_signal(\"module::lockscreen_show\")'" ""
-		]]
+		]],
 
 		-- You can add more start-up applications here
 	},


### PR DESCRIPTION
The reason? For previous of the other configurations, It will fail when copying and pasting their preferred auto-start applications.

At the left, a configured floppy config, and on the right, what the surreal config would look for something switching back on this config.

It will fail because it doesn’t finish the auto-lock timer line with a comma, to allow for the custom user lines to be entered.

![](https://user-images.githubusercontent.com/13170204/87313783-acfc5780-c522-11ea-93b5-cffb9ebb187c.png)