### PR TITLE
Fixed today pane and notification center in shortcut descriptions

### DIFF
--- a/config/awesome/floppy/configuration/keys/global.lua
+++ b/config/awesome/floppy/configuration/keys/global.lua
@@ -488,7 +488,7 @@ local globalKeys = awful.util.table.join(
 				_G.right_panel_mode = 'today_mode'
 			end
 		end,
-		{description = 'open notification center', group = 'launcher'}
+		{description = 'open today pane', group = 'launcher'}
 	),
 	awful.key(
 		{modkey}, 
@@ -511,7 +511,7 @@ local globalKeys = awful.util.table.join(
 				_G.right_panel_mode = 'notif_mode'
 			end
 		end,
-		{description = 'open today pane', group = 'launcher'}
+		{description = 'open notification center', group = 'launcher'}
 	)
 )
 

--- a/config/awesome/linear/configuration/keys/global.lua
+++ b/config/awesome/linear/configuration/keys/global.lua
@@ -488,7 +488,7 @@ local globalKeys = awful.util.table.join(
 				_G.right_panel_mode = 'today_mode'
 			end
 		end,
-		{description = 'open notification center', group = 'launcher'}
+		{description = 'open today pane', group = 'launcher'}
 	),
 	awful.key(
 		{modkey}, 
@@ -511,7 +511,7 @@ local globalKeys = awful.util.table.join(
 				_G.right_panel_mode = 'notif_mode'
 			end
 		end,
-		{description = 'open today pane', group = 'launcher'}
+		{description = 'open notification center', group = 'launcher'}
 	)
 )
 


### PR DESCRIPTION
In the overview for the shortcuts, the notification center and today pane descriptions were swapped around for their respective keybind actions.