### PR TITLE
Replace picom-tryone-git to picom-git following README.md

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,7 +11,7 @@ license=("AGPL3")
 depends=(
 	"awesome-git"
 	"rofi-git"
-	"picom-tryone-git"
+	"picom-git"
 	"inter-font"
 )
 optdepends=(


### PR DESCRIPTION
Since the tryone pr was merged into picom, the fork wasn´t necessary, but you forgot to update the PKGBUILD respectfully.
I haven´t modified rofi either, as i don´t know if the README.md change was voluntary or not.
Also, I´ve been a bit away on that, for which reason did you removed the PKGBUILD from the aur ?